### PR TITLE
fix: use singular 'day' when one day remains for product availability

### DIFF
--- a/client/src/components/ProductCard.tsx
+++ b/client/src/components/ProductCard.tsx
@@ -70,7 +70,11 @@ function ProductCard ({ product, bookmark, log }: Props) {
     if (daysBeforeEnd >= 0) {
       if (daysBeforeEnd < 6) {
         availModifier += ' ending';
-        availabilityMsg = `Only available for ${daysBeforeEnd} days!`;
+        if (daysBeforeEnd === 1) {
+          availabilityMsg = 'Only available for one more day!';
+        } else {
+          availabilityMsg = `Only available for ${daysBeforeEnd} more days!`;
+        }
       } else {
         availModifier += ' midlife';
         availabilityMsg = `Available until ${offerEndDate.toLocaleDateString()}`;


### PR DESCRIPTION
Resolves #165 

### REQUIRED:
- [x] Write the issue number associated with this pull request after "Resolves #"
- [x] Add the correct label for this pull request (you can just use the same label as the associated issue)
- [x] Be sure to share a link to this pull request in Slack/Discord and ask for a review! <3
