### PR TITLE
style: set Grid component to page width

### DIFF
--- a/client/src/styles/ProductGrid.css
+++ b/client/src/styles/ProductGrid.css
@@ -1,0 +1,3 @@
+.Grid {
+  width: 100vw;
+}


### PR DESCRIPTION
# Changes Made:

In a desktop view where only one product card is displayed, the width of the grid was not filling the entire page, making the product card looked squished. This PR sets the grid to always take the full page width to avoid this behavior.

## Issue No(s).:

Resolves #197

# Before Submitting:
- [x] I have included a clear description of the contents of my Pull Request.
- [x] I have linked the associated Issue(s) above.
  - "Resolves #[Issue No.]"
  - Include a new line for each Issue if more than one is covered.
  - If there is no associated Issue, this PR will not be approved.
- [x] I have included the appropriate labels.
  - They should match the labels for the associated Issue(s).

# After Submitting:
- One of the Oriori team will review your code.
- Changes may be requested before approval, so please be sure to keep an eye on the status of your PR.
